### PR TITLE
point at correct types file

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "require": "./dist/vue-interact.umd.cjs"
     }
   },
-  "types": "vue-interact.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
`vue-interact.d.ts` does not exist in the published package, which results in confusing TypeScript errors. This points at a file that does exist.