### PR TITLE
Fill in exports/other package.json fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vue-interact.js",
       "require": "./dist/vue-interact.umd.cjs"
     }
   },
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
+  "module": "./dist/vue-interact.js",
+  "main": "./dist/vue-interact.umd.cjs",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Apologies for all the PRs. I got two errors from 2.1.3:

- A TypeScript error that the `types` file existed but was not in `exports`.
- A module loader error that I didn't totally understand.

Adding "types" to the exports solved the first issue. Adding the top-level `module` and `main` fields solved the latter. I based this on https://github.com/MaxLeiter/sortablejs-vue3/blob/main/package.json.